### PR TITLE
DF-3195 fix "No test was administered" printing

### DIFF
--- a/forms-flow-rsbcservice/src/print/print_layout.json
+++ b/forms-flow-rsbcservice/src/print/print_layout.json
@@ -181,6 +181,7 @@
       "REQUESTED_PRESCRIBED_TEST_USED_DRUG_INSTRUMENT",
       "REQUESTED_PRESCRIBED_TEST_USED_DRUG_PPCT",
       "REQUESTED_APPROVED_INSTRUMENT",
+      "REQUESTED_NO_TEST_ADMINISTERED",
       "REQUESTED_TEST_TIME",
       "REQUESTED_TEST_BAC",
       "REQUESTED_TEST_BAC_RESULT",
@@ -940,6 +941,16 @@
         "start": {
           "x": 121.25,
           "y": 127.75
+        }
+      },      
+      "REQUESTED_NO_TEST_ADMINISTERED": {
+        "field_type": "checkbox",
+        "field_name": "requested_test_used_alcohol",
+        "field_val": "no-test",
+        "classNames": "fontSmall",
+        "start": {
+          "x": 121.25,
+          "y": 132
         }
       },
       "REQUESTED_APPROVED_INSTRUMENT": {


### PR DESCRIPTION
# Issue Tracking

JIRA: [DF-3195](https://jira.justice.gov.bc.ca/browse/DF-3195)
Issue Type: BUG

# Changes
Update print layout to correctly check the option "No test was administered" when required.
